### PR TITLE
Ana/fix lint fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "generate": "nuxt generate",
     "lint:js": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "lint:style": "stylelint **/*.{vue,css} --ignore-path .gitignore",
-    "lint": "yarn lint:js && yarn lint:style",
+    "lint": "yarn lint:style && yarn lint:js",
     "test:e2e": "wdio wdio.conf.js"
   },
   "lint-staged": {


### PR DESCRIPTION
`yarn lint --fix` command wasn't working simply due to the order of the commands in the "lint" script (`package.json`)