### PR TITLE
no results ... results!

### DIFF
--- a/components/staking/TableValidators.vue
+++ b/components/staking/TableValidators.vue
@@ -53,6 +53,7 @@
         />
       </tbody>
     </table>
+    <div v-if="!showingValidators.length" class="no-results">No results</div>
   </div>
 </template>
 
@@ -169,6 +170,12 @@ export default {
 }
 </script>
 <style scoped>
+.no-results {
+  text-align: center;
+  margin: 3em;
+  color: var(--dim);
+}
+
 @media screen and (max-width: 550px) {
   .data-table td {
     overflow: hidden;

--- a/pages/validators/index.vue
+++ b/pages/validators/index.vue
@@ -40,12 +40,6 @@
         :show-mobile-sorting="showMobileSorting"
         show-on-mobile="expectedReturns"
       />
-      <div
-        v-if="validators && validators.length === 0 && searchTerm"
-        class="no-results"
-      >
-        No results for these search terms
-      </div>
     </template>
   </TmPage>
 </template>
@@ -166,12 +160,6 @@ export default {
 
 .filter-toggle {
   margin-left: 1em;
-}
-
-.no-results {
-  text-align: center;
-  margin: 3em;
-  color: var(--dim);
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
closes #69 
<img width="840" alt="Screen Shot 2020-10-27 at 11 29 52 PM" src="https://user-images.githubusercontent.com/6021933/97387420-52f28880-18ac-11eb-9820-b4ed6e1e484b.png">
