### PR TITLE
some homepage updates 

### DIFF
--- a/components/address/LiSession.vue
+++ b/components/address/LiSession.vue
@@ -1,15 +1,15 @@
 <template>
-  <nuxt-link :to="route" class="tm-li-session" :class="{ card }">
-    <div v-if="icon" class="tm-li-session-icon">
+  <nuxt-link :to="route" class="li-session" :class="{ card }">
+    <div v-if="icon" class="icon">
       <i class="material-icons notranslate circle">{{ icon }}</i>
     </div>
-    <div class="tm-li-session-text">
-      <div class="tm-li-session-title">
-        <span>{{ title }}</span>
+    <div class="row">
+      <div class="text">
+        <div class="title">{{ title }}</div>
       </div>
-    </div>
-    <div class="tm-li-session-icon arrow">
-      <i class="material-icons notranslate">arrow_forward</i>
+      <div class="icon arrow">
+        <i class="material-icons notranslate">arrow_forward</i>
+      </div>
     </div>
   </nuxt-link>
 </template>
@@ -39,7 +39,7 @@ export default {
 </script>
 
 <style scoped>
-.tm-li-session {
+.li-session {
   display: flex;
   padding: 1.5rem;
   margin: 0.5rem 0;
@@ -48,17 +48,22 @@ export default {
   transition: background-color 0.2s ease;
 }
 
-.tm-li-session.card {
+.li-session.card {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  justify-content: space-between;
   height: 12rem;
+  padding: 2rem;
   margin: 0;
 }
 
-.tm-li-session:hover {
-  cursor: pointer;
-  background: var(--app-fg-hover);
+.li-session.card:first-child {
+  background-color: var(--primary-faded);
+}
+
+.li-session.card:first-child:hover {
+  background-color: var(--primary-faded-hover);
 }
 
 .arrow {
@@ -67,27 +72,36 @@ export default {
   position: relative;
 }
 
-.tm-li-session:hover .arrow {
+.card .arrow {
+  align-self: flex-end;
+}
+
+.li-session:hover {
+  cursor: pointer;
+  background: var(--app-fg-hover);
+}
+
+.li-session:hover .arrow {
   left: -2px;
 }
 
-.tm-li-session-icon {
+.icon {
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.tm-li-session-icon i {
+.icon i {
   font-size: 1.25rem;
 }
 
-.tm-li-session-title {
-  color: var(--bright);
+.title {
+  color: var(--dim);
   font-size: var(--h4);
   font-weight: 400;
 }
 
-.tm-li-session-text {
+.text {
   flex: 1;
   display: flex;
   justify-content: center;
@@ -95,12 +109,14 @@ export default {
   padding: 0 1rem;
 }
 
-.card .tm-li-session-text {
+.card .text {
   padding: 0 2rem 0 0;
 }
 
-.card .tm-li-session-icon {
-  align-self: flex-end;
+.row {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
 }
 
 .material-icons.circle {

--- a/components/common/UserMenu.vue
+++ b/components/common/UserMenu.vue
@@ -51,7 +51,7 @@ export default {
   font-weight: 900;
 }
 
-@media screen and (max-width: 1023px) {
+@media screen and (max-width: 667px) {
   .user-menu {
     justify-content: center;
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,20 +1,21 @@
 <template>
   <div class="content">
-    <img class="network-icon" src="~/assets/images/currencies/atom.png" />
+    <!-- <img class="network-icon" src="~/assets/images/currencies/atom.png" /> -->
     <h1>{{ network.name }}</h1>
     <h2>{{ network.description }}</h2>
     <div class="card-sign-in">
       <div class="session-list">
         <LiSession
-          title="Explore with any address"
+          title="Start staking"
           :card="true"
-          route="/explore"
+          icon="gesture"
+          route="/validators"
         />
-        <LiSession title="Create a new address" :card="true" route="/create" />
         <LiSession
-          title="Recover from seed phrase"
+          title="Explore"
           :card="true"
-          route="/recover"
+          icon="language"
+          route="/explore"
         />
       </div>
     </div>
@@ -25,9 +26,7 @@
           <a :href="network.website" target="_blank">Project Website</a>
         </li>
         <li>
-          <a :href="network.api_url + '/node_info'" target="_blank"
-            >Node Info</a
-          >
+          <a :href="network.apiURL + '/node_info'" target="_blank">Node Info</a>
         </li>
         <!-- <li>
           <a
@@ -63,7 +62,7 @@ export default {
 
 <style scoped>
 .content {
-  padding: 2rem;
+  padding: 1rem 2rem;
   margin: 0 auto;
   max-width: 800px;
 }

--- a/styles/themes/lunie-light.css
+++ b/styles/themes/lunie-light.css
@@ -10,6 +10,8 @@
   --app-fg: hsl(229, 100%, 98%);
   --app-fg-hover: hsl(229, 100%, 96%);
   --app-bg: #fff;
+  --primary-faded: hsla(7, 88%, 70%, 0.2);
+  --primary-faded-hover: hsla(7, 88%, 70%, 0.3);
 
   /* menu styles */
   --app-nav: hsl(229, 20%, 11%);


### PR DESCRIPTION
for @faboweb

- removed the duplicate logo
- brought the content higher up on page
- simplified options
- added primary color and icons

<img width="1440" alt="Screen Shot 2020-10-31 at 8 44 47 AM" src="https://user-images.githubusercontent.com/6021933/97779588-6c6a2d80-1b55-11eb-9bfe-9807282b5038.png">
