### PR TITLE
adjust styling for API error bars

### DIFF
--- a/components/common/Bar.vue
+++ b/components/common/Bar.vue
@@ -71,15 +71,14 @@ export default {
 .bar {
   width: 100%;
   padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
-  font-family: var(--sans);
+  border-radius: 0.25rem;
   background-color: transparent;
   font-size: 14px;
   font-weight: 400;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  color: var(--menu-bright);
+  color: black;
 }
 
 .bar.primary {
@@ -95,7 +94,8 @@ export default {
 }
 
 .bar.danger {
-  background-color: var(--danger);
+  border: 2px solid var(--danger);
+  background-color: var(--danger-faded);
 }
 
 .bar.info {

--- a/components/common/Notifications.vue
+++ b/components/common/Notifications.vue
@@ -23,7 +23,8 @@ export default {
 <style>
 .notification-container {
   position: fixed;
-  z-index: 10;
-  top: 4.5rem;
+  z-index: 9999;
+  top: 0;
+  right: 0;
 }
 </style>

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -9,6 +9,7 @@
   --success-faded: hsla(120, 61%, 45%, 0.15);
   --warning: hsl(22, 86%, 56%);
   --danger: hsl(0, 100%, 55%);
+  --danger-faded: hsl(0, 100%, 85%);
   --info: hsl(332, 47%, 23%);
   --sky-blue: hsl(217, 100%, 70%);
   --faded-blue: hsl(226, 30%, 60%);


### PR DESCRIPTION
before:
<img width="1038" alt="Screen Shot 2020-11-03 at 4 59 22 PM" src="https://user-images.githubusercontent.com/6021933/98045167-0c45e680-1df6-11eb-9c27-8ed4d76a4536.png">

after:
<img width="1035" alt="Screen Shot 2020-11-03 at 4 59 16 PM" src="https://user-images.githubusercontent.com/6021933/98045170-0cde7d00-1df6-11eb-908e-932fe4cb833d.png">