### PR TITLE
netlify config issues

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,11 +1,12 @@
 export default {
-  // Build the app as a static site instead of SSR 
+  // Build the app as a static site instead of Server Side Rendered (SSR)
   // (https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-mode/)
   ssr: false,
   target: 'static',
-  // For site generated in SPA mode (https://go.nuxtjs.dev/config-build)
+
+  // Use local 404 instead of redirecting to Netlify 404 (https://go.nuxtjs.dev/config-build)
   generate: {
-    fallback: true
+    fallback: true,
   },
 
   // Global page headers (https://go.nuxtjs.dev/config-head)
@@ -21,7 +22,7 @@ export default {
         hid: 'description',
         name: 'description',
         content:
-          'Lunie 3 is a simple forkable wallet and staking interface for proof-of-stake blockchains',
+          'Lunie 3 is a simple staking and governance interface for proof-of-stake blockchains',
       },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],


### PR DESCRIPTION
in addition to this - we set the build command in netlify to `npm run build` instead of `yarn generate` as `generate` is for static sites, not single page apps.