### PR TITLE
Ana/fix select account field in sign in modal

### DIFF
--- a/components/common/Field.vue
+++ b/components/common/Field.vue
@@ -211,6 +211,7 @@ textarea.tm-field {
 
 .tm-select {
   position: relative;
+  width: 100%;
 }
 
 .tm-select select {


### PR DESCRIPTION
Fixes this

![image](https://user-images.githubusercontent.com/40721795/99720136-960bda00-2aad-11eb-8511-a87065587278.png)


Not the field occupies the whole width:

![image](https://user-images.githubusercontent.com/40721795/99720170-a754e680-2aad-11eb-985d-cac629ed33a9.png)
