### PR TITLE
Fabo/key options correctly

### DIFF
--- a/components/common/Field.vue
+++ b/components/common/Field.vue
@@ -7,8 +7,8 @@
     @input="updateValue($event.target.value)"
   >
     <option
-      v-for="(option, index) in selectOptions"
-      :key="index"
+      v-for="option in selectOptions"
+      :key="option.value"
       :value="option.value"
     >
       {{ option.key }}


### PR DESCRIPTION
The field would use index for key. This doesn't work if the array changes. Always use a key value.

Ref #259