### PR TITLE
fix precision calculation error when factor is small

### DIFF
--- a/apis/cosmos-reducers-0.39.js
+++ b/apis/cosmos-reducers-0.39.js
@@ -59,8 +59,8 @@ export function coinReducer(chainCoin, ibcInfo) {
     }
   }
 
-  const precision = coinLookup.chainToViewConversionFactor
-    .toString()
+  const precision = BigNumber(coinLookup.chainToViewConversionFactor)
+    .toFixed()
     .split('.')[1].length
 
   return {

--- a/apis/cosmos-reducers.js
+++ b/apis/cosmos-reducers.js
@@ -59,8 +59,8 @@ export function coinReducer(chainCoin, ibcInfo) {
     }
   }
 
-  const precision = coinLookup.chainToViewConversionFactor
-    .toString()
+  const precision = BigNumber(coinLookup.chainToViewConversionFactor)
+    .toFixed()
     .split('.')[1].length
 
   return {


### PR DESCRIPTION
When I use `chainToViewConversionFactor: 1e-9` or `chainToViewConversionFactor: 0.000000001` in `network.js`, the reducer will convert to number to string `'1e-9'`, then call `'1e-9'.split('.')` which cause an error later on. 

This PR makes sure factors that are very small will convert to decimal properly for split, instead of the default scientific notation.
