### PR TITLE
fix cannot handle transaction amount array

### DIFF
--- a/components/transactions/TransactionItem.vue
+++ b/components/transactions/TransactionItem.vue
@@ -135,7 +135,9 @@ export default {
       if (this.transaction.details.amounts) {
         return this.transaction.details.amounts
       } else if (this.transaction.details.amount) {
-        return [this.transaction.details.amount]
+        return Array.isArray(this.transaction.details.amount)
+          ? this.transaction.details.amount
+          : [this.transaction.details.amount]
       }
       return null
     },


### PR DESCRIPTION
In a transfer transaction, `amount` could actually be an array
This PR detects if `amount` is already an array before returning

Not sure if this is cosmos sdk 0.3x specific, since we are still on 0.3x